### PR TITLE
Add approximate time ago method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taw (1.0.0pre)
+    taw (1.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ Taw.time_ago_in_words(Time.now - 63) + " ago"
 Taw.time_ago_in_words(Time.now - 60 * 60 * 2 - 63) + " ago"
 # => "2 hours and 1 minute and 3 seconds ago"
 
-Taw.approx_time_ago_in_words(Time.now - 60 * 60 * 26 - 63) + " ago"
-# => "1 day and 2 hours"
+Taw.time_ago_in_words(Time.now - 60 * 60 * 26 - 63, approx: 1) + " ago"
+# => "1 day ago"
+
+Taw.time_ago_in_words(Time.now - 60 * 60 * 26 - 63, approx: 2) + " ago"
+# => "1 day and 2 hours ago"
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Taw.time_ago_in_words(Time.now - 63) + " ago"
 
 Taw.time_ago_in_words(Time.now - 60 * 60 * 2 - 63) + " ago"
 # => "2 hours and 1 minute and 3 seconds ago"
+
+Taw.approx_time_ago_in_words(Time.now - 60 * 60 * 26 - 63) + " ago"
+# => "1 day and 2 hours"
 ```
 
 ## Installation

--- a/lib/taw.rb
+++ b/lib/taw.rb
@@ -12,11 +12,19 @@ module Taw
     Calculator.new.time_ago_in_words(time)
   end
 
+  def self.approx_time_ago_in_words(time)
+    Calculator.new.approx_time_ago_in_words(time)
+  end
+
   class Calculator
     def time_ago_in_words(time)
       self.distance = Time.now - time
       calculate_distance
       output_distance
+    end
+
+    def approx_time_ago_in_words(time)
+      time_ago_in_words(time).split(" and ")[0..1].join(" and ")
     end
 
     private

--- a/lib/taw.rb
+++ b/lib/taw.rb
@@ -8,23 +8,19 @@ module Taw
   MONTH_IN_SECONDS = DAY_IN_SECONDS * 30
   YEAR_IN_SECONDS = MONTH_IN_SECONDS * 12
 
-  def self.time_ago_in_words(time)
-    Calculator.new.time_ago_in_words(time)
-  end
-
-  def self.approx_time_ago_in_words(time)
-    Calculator.new.approx_time_ago_in_words(time)
+  def self.time_ago_in_words(time, opts = {})
+    Calculator.new(opts).time_ago_in_words(time)
   end
 
   class Calculator
+    def initialize(opts)
+      @approx_units = opts[:approx]
+    end
+
     def time_ago_in_words(time)
       self.distance = Time.now - time
       calculate_distance
       output_distance
-    end
-
-    def approx_time_ago_in_words(time)
-      time_ago_in_words(time).split(" and ")[0..1].join(" and ")
     end
 
     private
@@ -37,6 +33,11 @@ module Taw
       :weeks,
       :months,
       :years
+
+    def approx_units
+      return @approx_units - 1 if @approx_units
+      -1
+    end
 
     def calculate_distance
       while distance > 0
@@ -95,7 +96,7 @@ module Taw
         ("#{hours} #{pluralize(hours, "hour")}" if hours && hours > 0),
         ("#{minutes} #{pluralize(minutes, "minute")}" if minutes && minutes > 0),
         ("#{seconds} #{pluralize(seconds, "second")}" if seconds && seconds > 0)
-      ].compact.join(" and ")
+      ].drop_while(&:nil?)[0..approx_units].compact.join(" and ")
     end
 
     def pluralize(count, singular, plural = "#{singular}s")

--- a/lib/taw/version.rb
+++ b/lib/taw/version.rb
@@ -1,3 +1,3 @@
 module Taw
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/test/taw_test.rb
+++ b/test/taw_test.rb
@@ -21,12 +21,21 @@ class TawTest < Minitest::Test
     assert_equal "1 day and 2 hours and 1 minute and 4 seconds", Taw.time_ago_in_words(Time.now - 60 * 60 * 26 - 64)
   end
 
-  def test_approximation_is_reasonably_short
-    assert_equal "1 day and 2 hours", Taw.approx_time_ago_in_words(Time.now - 60 * 60 * 26 - 64)
+  def test_approximation_to_one_unit
+    assert_equal "1 day", Taw.time_ago_in_words(Time.now - 60 * 60 * 26 - 64, approx: 1)
+  end
+
+  def test_approximation_to_two_units
+    assert_equal "1 day and 2 hours", Taw.time_ago_in_words(Time.now - 60 * 60 * 26 - 64, approx: 2)
   end
 
   def test_approximation_rounds_down
-    assert_equal "2 hours and 59 minutes", Taw.approx_time_ago_in_words(Time.now - 60 * 60 * 3 + 1)
+    assert_equal "2 hours and 59 minutes", Taw.time_ago_in_words(Time.now - 60 * 60 * 3 + 1, approx: 2)
+  end
+
+  def test_approximation_does_not_skip_units
+    # Don't say 1 month and 1 minute because the minute is insignificant
+    assert_equal "1 month", Taw.time_ago_in_words(Time.now - 60 * 60 * 24 * 30 - 60, approx: 2)
   end
 
   def test_it_returns_days

--- a/test/taw_test.rb
+++ b/test/taw_test.rb
@@ -18,7 +18,15 @@ class TawTest < Minitest::Test
   end
 
   def test_it_returns_mixed_stuff
-    assert_equal "2 hours and 1 minute and 4 seconds", Taw.time_ago_in_words(Time.now - 60 * 60 * 2 - 64)
+    assert_equal "1 day and 2 hours and 1 minute and 4 seconds", Taw.time_ago_in_words(Time.now - 60 * 60 * 26 - 64)
+  end
+
+  def test_approximation_is_reasonably_short
+    assert_equal "1 day and 2 hours", Taw.approx_time_ago_in_words(Time.now - 60 * 60 * 26 - 64)
+  end
+
+  def test_approximation_rounds_down
+    assert_equal "2 hours and 59 minutes", Taw.approx_time_ago_in_words(Time.now - 60 * 60 * 3 + 1)
   end
 
   def test_it_returns_days


### PR DESCRIPTION
My use case is displaying `DateTime`s from a database in a more friendly
format.  This should be more useful for most of the folks who want words for
timestamps that are not round numbers of units ago.