### PR TITLE
Add output for times less than 1 second ago

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    taw (1.1.0)
+    taw (1.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -25,4 +25,4 @@ DEPENDENCIES
   taw!
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/shime/taw.svg?branch=master)](https://travis-ci.org/shime/taw)
 
 **T**ime **A**go in **W**ords helper for non Rails projects.
-No dependencies. No assumptions about your codebase. Minimalistic, ~80 SLOC.
+No dependencies. No assumptions about your codebase. Minimalistic, ~90 SLOC.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Taw.time_ago_in_words(Time.now - 63) + " ago"
 Taw.time_ago_in_words(Time.now - 60 * 60 * 2 - 63) + " ago"
 # => "2 hours and 1 minute and 3 seconds ago"
 
+Taw.time_ago_in_words(Time.now - 0.5) + " ago"
+# => "a moment ago"
+
 Taw.time_ago_in_words(Time.now - 60 * 60 * 26 - 63, approx: 1) + " ago"
 # => "1 day ago"
 

--- a/lib/taw.rb
+++ b/lib/taw.rb
@@ -88,7 +88,7 @@ module Taw
     end
 
     def output_distance
-      [
+      output = [
         ("#{years} #{pluralize(years, "year")}" if years && years > 0),
         ("#{months} #{pluralize(months, "month")}" if months && months > 0),
         ("#{weeks} #{pluralize(weeks, "week")}" if weeks && weeks > 0),
@@ -97,6 +97,8 @@ module Taw
         ("#{minutes} #{pluralize(minutes, "minute")}" if minutes && minutes > 0),
         ("#{seconds} #{pluralize(seconds, "second")}" if seconds && seconds > 0)
       ].drop_while(&:nil?)[0..approx_units].compact.join(" and ")
+      return "a moment" if output.empty?
+      output
     end
 
     def pluralize(count, singular, plural = "#{singular}s")

--- a/lib/taw/version.rb
+++ b/lib/taw/version.rb
@@ -1,3 +1,3 @@
 module Taw
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/test/taw_test.rb
+++ b/test/taw_test.rb
@@ -53,4 +53,8 @@ class TawTest < Minitest::Test
   def test_it_returns_years
     assert_equal "1 year", Taw.time_ago_in_words(Time.now - 60 * 60 * 24 * 30 * 12)
   end
+
+  def test_it_returns_moment
+    assert_equal "a moment", Taw.time_ago_in_words(Time.now - 0.5)
+  end
 end


### PR DESCRIPTION
Now I'd like to fix the display for when my page loads immediately after doing something.  The `time_ago_in_words` returns an empty string if the time was less than 1 second ago.